### PR TITLE
Call out opening bracket behavior in FAQ

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,6 +70,13 @@ support:
     git clone https://tpope.io/vim/surround.git
     vim -u NONE -c "helptags surround/doc" -c q
 
+## FAQ
+
+> How do I surround without adding a space?
+
+Only the opening brackets—`[`, `{`, and `(`—add a space.  Use a closing
+bracket, or the `b` (`(`) and `B` (`{`) aliases.
+
 ## Contributing
 
 See the contribution guidelines for


### PR DESCRIPTION
Apparently mentioning in the both the README intro and the help file isn't enough.  I give up.

Resolves: https://github.com/tpope/vim-surround/issues/366
Resolves: https://github.com/tpope/vim-surround/issues/363
Resolves: https://github.com/tpope/vim-surround/issues/314
Resolves: https://github.com/tpope/vim-surround/issues/303
Resolves: https://github.com/tpope/vim-surround/issues/240
Resolves: https://github.com/tpope/vim-surround/issues/205
Resolves: https://github.com/tpope/vim-surround/issues/108
Resolves: https://github.com/tpope/vim-surround/issues/27